### PR TITLE
experimental scroll and config loading

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,0 +1,48 @@
+"""Configuration for tmux-buddy.
+
+Holds the default socket name. Resolution order, highest priority first:
+  1. TMUX_MCP_SOCKET environment variable
+  2. defaultSocket field in the config JSON file
+  3. literal fallback "tmux-mcp"
+
+The config file path follows the same convention as permissions.py:
+  1. TMUX_MCP_CONFIG_FILE environment variable (full path)
+  2. $XDG_CONFIG_HOME/tmux-mcp/config.json
+  3. ~/.config/tmux-mcp/config.json
+"""
+
+import json
+import os
+from pathlib import Path
+
+
+FALLBACK_SOCKET = "tmux-mcp"
+
+
+def config_file_path() -> Path:
+    override = os.environ.get("TMUX_MCP_CONFIG_FILE")
+    if override:
+        return Path(override).expanduser()
+
+    xdg = os.environ.get("XDG_CONFIG_HOME")
+    if xdg:
+        return Path(xdg).expanduser() / "tmux-mcp" / "config.json"
+
+    return Path.home() / ".config" / "tmux-mcp" / "config.json"
+
+
+def default_socket() -> str:
+    env = os.environ.get("TMUX_MCP_SOCKET")
+    if env:
+        return env
+
+    try:
+        raw = config_file_path().read_text(encoding="utf-8")
+        data = json.loads(raw)
+        sock = data.get("defaultSocket")
+        if isinstance(sock, str) and sock:
+            return sock
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        pass
+
+    return FALLBACK_SOCKET

--- a/config_test.py
+++ b/config_test.py
@@ -1,0 +1,77 @@
+"""Tests for config loading (default socket name)."""
+
+import json
+
+import pytest
+
+import config
+
+
+def test_default_socket_env_var_takes_precedence(monkeypatch, tmp_path):
+    cfg = tmp_path / "config.json"
+    cfg.write_text(json.dumps({"defaultSocket": "filesock"}))
+    monkeypatch.setenv("TMUX_MCP_SOCKET", "envsock")
+    monkeypatch.setenv("TMUX_MCP_CONFIG_FILE", str(cfg))
+
+    assert config.default_socket() == "envsock"
+
+
+def test_default_socket_reads_config_file(monkeypatch, tmp_path):
+    cfg = tmp_path / "config.json"
+    cfg.write_text(json.dumps({"defaultSocket": "filesock"}))
+    monkeypatch.delenv("TMUX_MCP_SOCKET", raising=False)
+    monkeypatch.setenv("TMUX_MCP_CONFIG_FILE", str(cfg))
+
+    assert config.default_socket() == "filesock"
+
+
+def test_default_socket_fallback_when_no_env_or_file(monkeypatch, tmp_path):
+    monkeypatch.delenv("TMUX_MCP_SOCKET", raising=False)
+    monkeypatch.setenv("TMUX_MCP_CONFIG_FILE", str(tmp_path / "missing.json"))
+
+    assert config.default_socket() == "tmux-mcp"
+
+
+def test_default_socket_fallback_when_config_invalid_json(monkeypatch, tmp_path):
+    cfg = tmp_path / "config.json"
+    cfg.write_text("not valid json")
+    monkeypatch.delenv("TMUX_MCP_SOCKET", raising=False)
+    monkeypatch.setenv("TMUX_MCP_CONFIG_FILE", str(cfg))
+
+    assert config.default_socket() == "tmux-mcp"
+
+
+def test_default_socket_fallback_when_key_missing(monkeypatch, tmp_path):
+    cfg = tmp_path / "config.json"
+    cfg.write_text(json.dumps({"unrelated": "value"}))
+    monkeypatch.delenv("TMUX_MCP_SOCKET", raising=False)
+    monkeypatch.setenv("TMUX_MCP_CONFIG_FILE", str(cfg))
+
+    assert config.default_socket() == "tmux-mcp"
+
+
+def test_config_file_path_env_override(monkeypatch, tmp_path):
+    target = tmp_path / "custom.json"
+    monkeypatch.setenv("TMUX_MCP_CONFIG_FILE", str(target))
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+
+    assert config.config_file_path() == target
+
+
+def test_config_file_path_uses_xdg(monkeypatch, tmp_path):
+    monkeypatch.delenv("TMUX_MCP_CONFIG_FILE", raising=False)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+    assert config.config_file_path() == tmp_path / "tmux-mcp" / "config.json"
+
+
+def test_config_file_path_default(monkeypatch, tmp_path):
+    monkeypatch.delenv("TMUX_MCP_CONFIG_FILE", raising=False)
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    assert config.config_file_path() == tmp_path / ".config" / "tmux-mcp" / "config.json"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tmux_cli.py
+++ b/tmux_cli.py
@@ -27,7 +27,7 @@ def cmd_new(args):
     """Create a new tmux session and attach to it."""
     # Check if session name is a valid color
     color = args.session_name if tmux_lib.is_valid_color(args.session_name) else None
-    
+
     if args.record:
         if shutil.which("asciinema") is None:
             print(
@@ -36,7 +36,18 @@ def cmd_new(args):
                 )
             sys.exit(1)
 
-    if tmux_lib.create_tmux_session(args.session_name, color=color):
+    try:
+        socket = tmux_lib.create_tmux_session(
+            args.session_name,
+            color=color,
+            scroll_popup=args.experimental_scroll_popup,
+            return_socket=True,
+        )
+    except tmux_lib.SessionNameConflictError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    if socket:
         if color:
             print(f"Tmux session ready with {color} status bar: {args.session_name}")
         else:
@@ -52,12 +63,16 @@ def cmd_new(args):
                     "asciinema",
                     "rec",
                     "--command",
-                    f"tmux attach-session -t {args.session_name}",
+                    f"tmux -L {socket} "
+                    f"attach-session -t {args.session_name}",
                     filename,
                 ]
             )
         else:
-            subprocess.run(["tmux", "attach-session", "-t", args.session_name])
+            subprocess.run([
+                "tmux", "-L", socket,
+                "attach-session", "-t", args.session_name,
+            ])
     else:
         print(f"Failed to create tmux session: {args.session_name}", file=sys.stderr)
         sys.exit(1)
@@ -118,6 +133,16 @@ def main():
         "--record",
         action="store_true",
         help="Record the tmux session using asciinema",
+    )
+    new_parser.add_argument(
+        "--experimental-scroll-popup",
+        action="store_true",
+        help=(
+            "Experimental: mouse-wheel-up on any pane opens a popup "
+            "viewer of the pane's piped output (via less) instead of "
+            "entering copy-mode. Installs per-session hooks and a "
+            "WheelUpPane key bind gated on @tmux_mcp_managed."
+        ),
     )
     new_parser.set_defaults(func=cmd_new)
 

--- a/tmux_cli_test.py
+++ b/tmux_cli_test.py
@@ -10,6 +10,7 @@ from io import StringIO
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '.')))
 
 import tmux_cli
+import tmux_lib
 
 class TestTmuxCli(unittest.TestCase):
 
@@ -17,17 +18,69 @@ class TestTmuxCli(unittest.TestCase):
     @mock.patch('tmux_cli.subprocess.run')
     @mock.patch('tmux_cli.print')
     def test_cmd_new_no_record(self, mock_print, mock_subprocess_run, mock_create_tmux_session):
-        mock_create_tmux_session.return_value = True
-        
+        mock_create_tmux_session.return_value = 'tmux-mcp'
+
         args = mock.Mock()
         args.session_name = 'test_session'
         args.record = False
+        args.experimental_scroll_popup = False
 
         tmux_cli.cmd_new(args)
 
-        mock_create_tmux_session.assert_called_once_with('test_session', color=None)
-        mock_subprocess_run.assert_called_once_with(['tmux', 'attach-session', '-t', 'test_session'])
+        mock_create_tmux_session.assert_called_once_with(
+            'test_session', color=None, scroll_popup=False, return_socket=True,
+        )
+        mock_subprocess_run.assert_called_once_with(
+            ['tmux', '-L', 'tmux-mcp', 'attach-session', '-t', 'test_session']
+        )
         mock_print.assert_called_with('Tmux session ready: test_session')
+
+    @mock.patch('tmux_cli.tmux_lib.create_tmux_session')
+    @mock.patch('tmux_cli.subprocess.run')
+    @mock.patch('tmux_cli.print')
+    def test_cmd_new_with_experimental_scroll_popup_uses_experimental_socket(
+        self, mock_print, mock_subprocess_run, mock_create_tmux_session
+    ):
+        mock_create_tmux_session.return_value = 'tmux-mcp-experimental-scroll'
+
+        args = mock.Mock()
+        args.session_name = 'exp_session'
+        args.record = False
+        args.experimental_scroll_popup = True
+
+        tmux_cli.cmd_new(args)
+
+        mock_create_tmux_session.assert_called_once_with(
+            'exp_session', color=None, scroll_popup=True, return_socket=True,
+        )
+        mock_subprocess_run.assert_called_once_with(
+            ['tmux', '-L', 'tmux-mcp-experimental-scroll', 'attach-session', '-t', 'exp_session']
+        )
+
+    @mock.patch('tmux_cli.tmux_lib.create_tmux_session')
+    @mock.patch('tmux_cli.sys.exit')
+    @mock.patch('sys.stderr', new_callable=StringIO)
+    def test_cmd_new_hard_fails_on_session_name_conflict(
+        self, mock_stderr, mock_sys_exit, mock_create_tmux_session
+    ):
+        mock_create_tmux_session.side_effect = tmux_lib.SessionNameConflictError(
+            'green', 'tmux-mcp', 'tmux-mcp-experimental-scroll'
+        )
+        mock_sys_exit.side_effect = SystemExit
+
+        args = mock.Mock()
+        args.session_name = 'green'
+        args.record = False
+        args.experimental_scroll_popup = True
+
+        with self.assertRaises(SystemExit):
+            tmux_cli.cmd_new(args)
+
+        mock_sys_exit.assert_called_with(1)
+        # The error message should name the conflicting session and socket.
+        err = mock_stderr.getvalue()
+        self.assertIn('green', err)
+        self.assertIn('tmux-mcp', err)
 
     @mock.patch('tmux_cli.tmux_lib.create_tmux_session')
     @mock.patch('tmux_cli.shutil.which')
@@ -46,7 +99,7 @@ class TestTmuxCli(unittest.TestCase):
         mock_shutil_which,
         mock_create_tmux_session
     ):
-        mock_create_tmux_session.return_value = True
+        mock_create_tmux_session.return_value = 'tmux-mcp'
         mock_shutil_which.return_value = '/usr/bin/asciinema' # asciinema is installed
 
         # Mock datetime to control the timestamp in the filename
@@ -57,19 +110,23 @@ class TestTmuxCli(unittest.TestCase):
         args = mock.Mock()
         args.session_name = 'test_recorded_session'
         args.record = True
+        args.experimental_scroll_popup = False
 
         tmux_cli.cmd_new(args)
 
         mock_shutil_which.assert_called_once_with('asciinema')
         mock_os_makedirs.assert_called_once_with('/home/user/.tmux-session-recordings', exist_ok=True)
-        mock_create_tmux_session.assert_called_once_with('test_recorded_session', color=None)
-        
+        mock_create_tmux_session.assert_called_once_with(
+            'test_recorded_session', color=None, scroll_popup=False, return_socket=True,
+        )
+
         expected_filename = '/home/user/.tmux-session-recordings/test_recorded_session_2026-05-03_10-30-00.cast'
         mock_subprocess_run.assert_called_once_with([
             'asciinema',
             'rec',
             '--command',
-            'tmux attach-session -t test_recorded_session',
+            'tmux -L tmux-mcp '
+            'attach-session -t test_recorded_session',
             expected_filename,
         ])
         mock_print.assert_called_with('Tmux session ready: test_recorded_session')

--- a/tmux_lib.py
+++ b/tmux_lib.py
@@ -10,6 +10,7 @@ from typing import NamedTuple
 
 from colors import VALID_COLORS
 
+import config
 import permissions
 
 from pathlib import Path
@@ -19,6 +20,72 @@ PROMPT_ARROW = "__>"
 
 # Seconds to wait before confirming interactive mode to avoid false positives
 INTERACTIVE_DETECTION_DELAY = 1.0
+
+# Suffix appended to the default socket to derive the dedicated socket
+# for sessions that opt into the experimental scroll-popup behaviour.
+# The popup needs server-global key rebinds (WheelUpPane) that would
+# otherwise leak into non-experimental sessions on the same server.
+SCROLL_POPUP_SUFFIX = "-experimental-scroll"
+
+
+def default_socket() -> str:
+    """Default tmux socket name. Wraps config.default_socket()."""
+    return config.default_socket()
+
+
+def scroll_popup_socket() -> str:
+    """Socket hosting sessions with the experimental scroll-popup feature."""
+    return default_socket() + SCROLL_POPUP_SUFFIX
+
+
+def managed_sockets() -> list[str]:
+    """Every tmux socket this build of tmux-buddy knows how to manage.
+
+    Default first, then the experimental-scroll socket. Iterated by
+    resolve_socket so newly-added sockets are automatically monitored
+    even when no sessions live on them yet.
+    """
+    return [default_socket(), scroll_popup_socket()]
+
+
+class SessionNameConflictError(Exception):
+    """A session of the same name lives on a different managed socket."""
+
+    def __init__(self, session_name: str, existing_socket: str, target_socket: str):
+        self.session_name = session_name
+        self.existing_socket = existing_socket
+        self.target_socket = target_socket
+        super().__init__(
+            f"Session '{session_name}' already exists on socket "
+            f"'{existing_socket}'; cannot create it on '{target_socket}'."
+        )
+
+
+class SessionNotFoundError(Exception):
+    """The named session is not on any managed socket."""
+
+    def __init__(self, session_name: str):
+        self.session_name = session_name
+        super().__init__(
+            f"Session '{session_name}' was not found on any managed socket: "
+            f"{managed_sockets()}"
+        )
+
+
+def resolve_socket(session_name: str) -> str:
+    """Return the managed socket hosting `session_name`.
+
+    Scans every socket in managed_sockets() on each call (no caching).
+    Raises SessionNotFoundError if the name is not on any of them.
+    """
+    for socket in managed_sockets():
+        result = subprocess.run(
+            ["tmux", "-L", socket, "list-sessions", "-F", "#S"],
+            capture_output=True, text=True,
+        )
+        if result.returncode == 0 and session_name in result.stdout.split("\n"):
+            return socket
+    raise SessionNotFoundError(session_name)
 
 
 def is_valid_color(name: str) -> bool:
@@ -32,17 +99,11 @@ def is_valid_color(name: str) -> bool:
     return name.lower() in VALID_COLORS
 
 
-def _set_status_bar_color(session_name: str, color: str) -> bool:
-    """Set the tmux status bar background color.
-
-    Args:
-        session_name: Name of the tmux session
-        color: Color name to set
-    Returns:
-        True if successful, False otherwise
-    """
+def _set_status_bar_color(socket: str, session_name: str, color: str) -> bool:
+    """Set the tmux status bar background color on the given socket."""
     result = subprocess.run(
-        ["tmux", "set-option", "-t", session_name, "status-style", f"bg={color}"],
+        ["tmux", "-L", socket, "set-option", "-t", session_name,
+         "status-style", f"bg={color}"],
         capture_output=True,
         text=True,
     )
@@ -63,7 +124,7 @@ class PromptVerificationError(Exception):
 
 
 # PS1 prompt to be set in the tmux session.
-TMUX_PS1 = r"$(kube_ps1) %c %(?.%F{green}__>.%F{red}__>)%f "
+TMUX_PS1 = r"·$(kube_ps1) %c %(?.%F{green}__>.%F{red}__>)%f "
 
 
 def _repo_script_path(script_name: str) -> str:
@@ -72,19 +133,139 @@ def _repo_script_path(script_name: str) -> str:
     return str((Path(__file__).resolve().parent / "scripts" / script_name))
 
 
-def create_tmux_session(session_name: str, color: str | None = None) -> bool:
+# Perl filter stripping control sequences from the popup log so less -R
+# only sees SGR colour codes and printable text. Mirrors the body of
+# tmux-scroll-viewer's bin/log-view.sh.
+_SCROLL_POPUP_FILTER = r"""
+s/\x1b\][^\x1b\x07]*(?:\x07|\x1b\\)//g;
+s/\x1b[PXk^_][^\x1b]*\x1b\\//g;
+s/\x1b\[[\d;?]*[A-LN-Za-ln-z]//g;
+s/\x1b[^\[\]PXk^_]//g;
+s/\r+\n/\n/g;
+s/[^\n]*\r//g;
+s/\A\n+//;
+"""
+
+
+def _setup_scroll_popup(socket: str, session_name: str) -> None:
+    """Install the wheel-up scroll-popup hooks/keybind on `socket`.
+
+    Mouse-wheel-up opens a display-popup viewer of the piped pane log
+    (via less -R) instead of entering copy-mode. The WheelUpPane bind
+    is server-global, so this must run on the experimental-scroll
+    socket only.
+    """
+    # Marker for the popup bind to gate on.
+    subprocess.run(
+        ["tmux", "-L", socket, "set-option", "-t", session_name,
+         "@tmux_mcp_scroll_popup", "1"],
+        capture_output=True, text=True,
+    )
+
+    # Stash the perl filter on tmux env so the popup bind can read it
+    # via $ENV{TMUX_MCP_FILTER} (avoids nested shell-quoting).
+    subprocess.run(
+        ["tmux", "-L", socket, "set-environment", "-t", session_name,
+         "TMUX_MCP_FILTER", _SCROLL_POPUP_FILTER],
+        capture_output=True, text=True,
+    )
+
+    # Mirror each new pane's raw output to /tmp/tmux-pane-<session>-<id>.log.
+    pipe_cmd = (
+        'pipe-pane -o '
+        '"cat > /tmp/tmux-pane-#{session_name}-#{pane_id}.log"'
+    )
+    for hook in ("after-new-window", "after-split-window"):
+        subprocess.run(
+            ["tmux", "-L", socket, "set-hook", "-t", session_name,
+             hook, pipe_cmd],
+            capture_output=True, text=True,
+        )
+
+    cleanup_cmd = (
+        'run-shell '
+        '"rm -f /tmp/tmux-pane-#{hook_session_name}-#{hook_pane}.log"'
+    )
+    for hook in ("pane-exited", "pane-died"):
+        subprocess.run(
+            ["tmux", "-L", socket, "set-hook", "-t", session_name,
+             hook, cleanup_cmd],
+            capture_output=True, text=True,
+        )
+
+    # Start the pipe for the initial pane (guarded so re-running setup is a no-op;
+    # `pipe-pane -o` toggles if a pipe is already open).
+    guarded_pipe = (
+        f'pipe-pane -t {session_name} '
+        '"cat > /tmp/tmux-pane-#{session_name}-#{pane_id}.log"'
+    )
+    subprocess.run(
+        ["tmux", "-L", socket, "if-shell", "-F", "-t", session_name,
+         "#{?pane_pipe,0,1}", guarded_pipe],
+        capture_output=True, text=True,
+    )
+
+    subprocess.run(
+        ["tmux", "-L", socket, "unbind-key", "-T", "root", "WheelUpPane"],
+        capture_output=True, text=True,
+    )
+
+    # Bind popup action to mouse-wheel up.
+    popup_cmd = (
+        'tmux display-popup -E -w 90% -h 90% '
+        '"perl -0777 -pe \\"eval \\\\\\$ENV{TMUX_MCP_FILTER}\\" '
+        '< /tmp/tmux-pane-#{session_name}-#{pane_id}.log '
+        '| less --mouse -R -f -X -e +G" || true'
+    )
+    popup_action = f"run-shell -b '{popup_cmd}'"
+    passthrough_cond = (
+        '#{||:#{alternate_on},#{pane_in_mode},#{mouse_any_flag},'
+        '#{!=:#{@tmux_mcp_scroll_popup},1}}'
+    )
+    subprocess.run(
+        ["tmux", "-L", socket, "bind-key", "-T", "root", "WheelUpPane",
+         "if-shell", "-F", passthrough_cond,
+         "send-keys -M",
+         popup_action],
+        capture_output=True, text=True,
+    )
+
+
+def create_tmux_session(
+    session_name: str,
+    color: str | None = None,
+    scroll_popup: bool = False,
+    return_socket: bool = False,
+) -> bool | str:
     """
     Create a new detached tmux session with predefined settings and PS1.
     Attaches to existing session if one already exists.
     Args:
         session_name: Name for the tmux session
         color: Optional color name to set the status bar background
+        scroll_popup: If True, create on the experimental-scroll socket
+            and install the wheel-up popup hooks.
+        return_socket: If True, return the socket name (str) instead of a bool.
     Returns:
-        True if session was created/attached successfully, False otherwise
+        True/socket-name on success, False on failure. Raises
+        SessionNameConflictError if the name lives on another managed socket.
     """
+    socket = scroll_popup_socket() if scroll_popup else default_socket()
+
+    # Reject cross-socket dups: tmux new-session -A only sees the target socket.
+    for other in managed_sockets():
+        if other == socket:
+            continue
+        result = subprocess.run(
+            ["tmux", "-L", other, "list-sessions", "-F", "#S"],
+            capture_output=True, text=True,
+        )
+        if result.returncode == 0 and session_name in result.stdout.split("\n"):
+            raise SessionNameConflictError(session_name, other, socket)
+
     # Create a new detached session, or attach if it already exists
     create_result = subprocess.run(
-        ["tmux", "new-session", "-Ad", "-s", session_name],
+        ["tmux", "-L", socket, "new-session", "-Ad", "-s", session_name],
         capture_output=True,
         text=True,
     )
@@ -94,34 +275,39 @@ def create_tmux_session(session_name: str, color: str | None = None) -> bool:
 
     # Set scrollback buffer size
     subprocess.run(
-        ["tmux", "set-option", "-g", "history-limit", "250000"],
+        ["tmux", "-L", socket, "set-option", "-t", session_name,
+         "history-limit", "250000"],
         capture_output=True,
         text=True,
     )
 
     # Enable mouse mode
     subprocess.run(
-        ["tmux", "set-option", "-g", "mouse", "on"], capture_output=True, text=True
+        ["tmux", "-L", socket, "set-option", "-t", session_name,
+         "mouse", "on"],
+        capture_output=True, text=True,
     )
 
     # Set terminal title
     subprocess.run(
-        ["tmux", "set-option", "-t", session_name, "set-titles", "on"],
+        ["tmux", "-L", socket, "set-option", "-t", session_name,
+         "set-titles", "on"],
         capture_output=True, text=True
     )
     subprocess.run(
-        ["tmux", "set-option", "-t", session_name, "set-titles-string", "#S / #W"],
+        ["tmux", "-L", socket, "set-option", "-t", session_name,
+         "set-titles-string", "#S / #W"],
         capture_output=True, text=True
     )
 
     # Set status bar color if a valid color is provided
     if color and is_valid_color(color):
-        _set_status_bar_color(session_name, color)
+        _set_status_bar_color(socket, session_name, color)
 
     # Set the PS1 prompt
     ps1_export = f"export PS1='{TMUX_PS1}'\n"
     subprocess.run(
-        ["tmux", "send-keys", "-t", session_name, ps1_export],
+        ["tmux", "-L", socket, "send-keys", "-t", session_name, ps1_export],
         capture_output=True,
         text=True,
     )
@@ -135,67 +321,52 @@ def create_tmux_session(session_name: str, color: str | None = None) -> bool:
 
     # Mark session as managed by tmux-mcp
     subprocess.run(
-        ["tmux", "set-option", "-t", session_name, "@tmux_mcp_managed", "1"],
+        ["tmux", "-L", socket, "set-option", "-t", session_name,
+         "@tmux_mcp_managed", "1"],
         capture_output=True,
         text=True,
     )
 
     subprocess.run(
-        ["tmux", "set-option", "-t", session_name, "status", "on"],
+        ["tmux", "-L", socket, "set-option", "-t", session_name,
+         "status", "on"],
         capture_output=True,
         text=True,
     )
     subprocess.run(
-        ["tmux", "set-option", "-t", session_name, "status-interval", "5"],
+        ["tmux", "-L", socket, "set-option", "-t", session_name,
+         "status-interval", "5"],
         capture_output=True,
         text=True,
     )
     subprocess.run(
-        [
-            "tmux",
-            "set-option",
-            "-t",
-            session_name,
-            "status-right",
-            f"#( {status_script} --session '#S' )",
-        ],
+        ["tmux", "-L", socket, "set-option", "-t", session_name,
+         "status-right", f"#( {status_script} --session '#S' )"],
         capture_output=True,
         text=True,
     )
 
-    # Global no-prefix key: cycle permissions and refresh status line immediately.
-    # Note: key bindings can't be scoped per-session; they are global.
-    # We gate via @tmux_mcp_managed.
-    #
-    # Key choice: Ctrl+] (rarely used by tmux defaults).
+    # Ctrl+] (global, gated on @tmux_mcp_managed): cycle permissions + refresh status.
     subprocess.run(
-        [
-            "tmux",
-            "bind-key",
-            "-n",
-            "C-]",
-            "run-shell",
-            f"[ "
-            f"\"$(tmux show-option -t '#S' -qv @tmux_mcp_managed)\" = '1' "
-            f"] && {toggle_script} --session '#S' >/dev/null 2>&1; tmux refresh-client -S",
-        ],
+        ["tmux", "-L", socket, "bind-key", "-n", "C-]", "run-shell",
+         f"[ "
+         f"\"$(tmux show-option -t '#S' -qv @tmux_mcp_managed)\" = '1' "
+         f"] && {toggle_script} --session '#S' >/dev/null 2>&1; tmux refresh-client -S"],
         capture_output=True,
         text=True,
     )
 
-    return True
+    if scroll_popup:
+        _setup_scroll_popup(socket, session_name)
+
+    return socket if return_socket else True
 
 
-def _capture_pane(session_name: str) -> str:
-    """
-    Capture the current pane content.
-    Args:
-        session_name: Name of the tmux session
-    Returns:
-        The captured pane content as a string
-    """
+def _capture_pane(socket: str, session_name: str) -> str:
+    """Capture the current pane content on the given socket."""
     result = subprocess.run(
-        ["tmux", "capture-pane", "-p", "-S", "-", "-t", session_name],
+        ["tmux", "-L", socket, "capture-pane", "-p", "-S", "-",
+         "-t", session_name],
         capture_output=True,
         text=True,
         check=True,
@@ -238,7 +409,8 @@ def get_n_last_lines(session_name: str, lines: int = 10) -> str:
     Returns:
         The last N lines as a string
     """
-    content = _capture_pane(session_name)
+    socket = resolve_socket(session_name)
+    content = _capture_pane(socket, session_name)
     content_lines = content.split("\n")
 
     # Strip control characters from each line
@@ -266,16 +438,11 @@ def get_n_last_lines(session_name: str, lines: int = 10) -> str:
     return "\n".join(trimmed[-lines:])
 
 
-def _verify_terminal_prompt(session_name: str, verify_string: str) -> bool:
-    """
-    Verify if the terminal prompt contains a specific string.
-    Args:
-        session_name: Name of the tmux session
-        verify_string: String to check for in the prompt
-    Returns:
-        True if the string is found, False otherwise
-    """
-    content = _capture_pane(session_name)
+def _verify_terminal_prompt(
+    socket: str, session_name: str, verify_string: str
+) -> bool:
+    """Check whether the prompt on the named session contains a string."""
+    content = _capture_pane(socket, session_name)
     lines = content.rstrip("\n").split("\n")
     # Check the last non-empty line for prompt
     last_line = ""
@@ -311,25 +478,29 @@ def send_to_terminal(
     Returns:
         True if command was sent, False if prompt verification failed
     """
+    socket = resolve_socket(session_name)
     if prompt_verify_string is not None:
         if not _verify_terminal_prompt(
-            session_name=session_name, verify_string=prompt_verify_string
+            socket=socket,
+            session_name=session_name,
+            verify_string=prompt_verify_string,
         ):
             return False
 
     buffer_name = _generate_random_buffer_name(prefix=session_name)
     try:
         subprocess.run(
-            ["tmux", "set-buffer", "-b", buffer_name, command],
+            ["tmux", "-L", socket, "set-buffer", "-b", buffer_name, command],
             capture_output=True, text=True
         )
         subprocess.run(
-            ["tmux", "paste-buffer", "-p", "-b", buffer_name, "-t", session_name],
+            ["tmux", "-L", socket, "paste-buffer", "-p", "-b", buffer_name,
+             "-t", session_name],
             capture_output=True, text=True
         )
     finally:
         subprocess.run(
-            ["tmux", "delete-buffer", "-b", buffer_name],
+            ["tmux", "-L", socket, "delete-buffer", "-b", buffer_name],
             capture_output=True, text=True
         )
 
@@ -337,13 +508,11 @@ def send_to_terminal(
 
 
 def send_interrupt(session_name: str) -> None:
-    """
-    Send CTRL+C interrupt to the terminal.
-    Args:
-        session_name: Name of the tmux session
-    """
+    """Send CTRL+C interrupt to the terminal."""
+    socket = resolve_socket(session_name)
     subprocess.run(
-        ["tmux", "send-keys", "-t", session_name, "C-c"], capture_output=True, text=True
+        ["tmux", "-L", socket, "send-keys", "-t", session_name, "C-c"],
+        capture_output=True, text=True
     )
 
 
@@ -360,6 +529,19 @@ def wait_for_command_completion(
         CommandOutput with status "free" if completed, "interactive" if
         interactive program detected, or None if timeout
     """
+    socket = resolve_socket(session_name)
+    return _wait_for_command_completion_on(
+        socket, session_name, timeout, poll_interval
+    )
+
+
+def _wait_for_command_completion_on(
+    socket: str,
+    session_name: str,
+    timeout: float = 30,
+    poll_interval: float = 0.001,
+) -> CommandOutput | None:
+    """Caller supplies the socket; avoids re-resolving on every poll."""
     start_time = time.time()
     last_output = None
 
@@ -369,7 +551,7 @@ def wait_for_command_completion(
     while time.time() - start_time < timeout:
         time.sleep(poll_interval)
 
-        result = get_last_command(session_name)
+        result = _get_last_command_on(socket, session_name)
         if result is None:
             continue
 
@@ -428,34 +610,42 @@ def execute_in_terminal(
         If sync=True: CommandOutput with output and status, or None if timeout
         If sync=False: Empty string on success, None if verification failed
     """
+    socket = resolve_socket(session_name)
     if prompt_verify_string is not None:
         if not _verify_terminal_prompt(
-            session_name=session_name, verify_string=prompt_verify_string
+            socket=socket,
+            session_name=session_name,
+            verify_string=prompt_verify_string,
         ):
             raise PromptVerificationError(
                 f"Prompt does not contain '{prompt_verify_string}'"
             )
 
     subprocess.run(
-        ["tmux", "send-keys", "-t", session_name, command + "\n"],
+        ["tmux", "-L", socket, "send-keys", "-t", session_name,
+         command + "\n"],
         capture_output=True,
         text=True,
     )
     if not sync:
         return ""
 
-    return wait_for_command_completion(session_name, timeout, poll_interval)
+    return _wait_for_command_completion_on(
+        socket, session_name, timeout, poll_interval
+    )
 
 
 def get_last_command(session_name: str) -> CommandOutput | None:
-    """
-    Extract the last command and its output from terminal output.
-    Args:
-        session_name: Name of the tmux session
-    Returns:
-        CommandOutput with prompt, command, and output, or None if not found
-    """
-    terminal_output = _capture_pane(session_name)
+    """Extract the last command and its output from the named session."""
+    socket = resolve_socket(session_name)
+    return _get_last_command_on(socket, session_name)
+
+
+def _get_last_command_on(
+    socket: str, session_name: str
+) -> CommandOutput | None:
+    """Caller supplies the socket."""
+    terminal_output = _capture_pane(socket, session_name)
     lines = terminal_output.strip().split("\n")
 
     # Find all prompt line indices (lines containing the prompt arrow)

--- a/tmux_lib_test.py
+++ b/tmux_lib_test.py
@@ -7,6 +7,193 @@ import permissions
 from unittest.mock import MagicMock, call
 
 
+class TestSocketTopology:
+    """Tests for socket-name helpers (default_socket, scroll_popup_socket, managed_sockets)."""
+
+    def test_scroll_popup_socket_suffixes_default(self, monkeypatch):
+        monkeypatch.setenv("TMUX_MCP_SOCKET", "foo")
+        assert tmux_lib.scroll_popup_socket() == "foo-experimental-scroll"
+
+    def test_scroll_popup_socket_uses_fallback_when_unset(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.delenv("TMUX_MCP_SOCKET", raising=False)
+        monkeypatch.setenv("TMUX_MCP_CONFIG_FILE", str(tmp_path / "missing.json"))
+        assert tmux_lib.scroll_popup_socket() == "tmux-mcp-experimental-scroll"
+
+    def test_managed_sockets_lists_both(self, monkeypatch):
+        monkeypatch.setenv("TMUX_MCP_SOCKET", "tmux-mcp")
+        sockets = tmux_lib.managed_sockets()
+        assert sockets == ["tmux-mcp", "tmux-mcp-experimental-scroll"]
+
+    def test_managed_sockets_reflects_custom_default(self, monkeypatch):
+        monkeypatch.setenv("TMUX_MCP_SOCKET", "myname")
+        assert tmux_lib.managed_sockets() == [
+            "myname",
+            "myname-experimental-scroll",
+        ]
+
+
+class TestResolveSocket:
+    """resolve_socket scans managed sockets via tmux list-sessions.
+    Returns the hosting socket; raises SessionNotFoundError if missing.
+    Recomputes every call (no caching).
+    """
+
+    def _make_run(self, sessions_per_socket):
+        """Fake subprocess.run honoring a {socket: {session, ...}} map.
+
+        None as the value simulates a socket with no running server.
+        """
+
+        def _run(cmd, capture_output=True, text=True, check=False):
+            assert cmd[:2] == ["tmux", "-L"]
+            sock = cmd[2]
+            if cmd[3:4] == ["list-sessions"]:
+                value = sessions_per_socket.get(sock)
+                if value is None:
+                    return MagicMock(returncode=1, stdout="", stderr="no server")
+                return MagicMock(
+                    returncode=0,
+                    stdout="\n".join(sorted(value)) + ("\n" if value else ""),
+                    stderr="",
+                )
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        return _run
+
+    def test_finds_session_on_default_socket(self, monkeypatch):
+        monkeypatch.setenv("TMUX_MCP_SOCKET", "tmux-mcp")
+        monkeypatch.setattr(
+            tmux_lib.subprocess, "run",
+            self._make_run({
+                "tmux-mcp": {"green", "blue"},
+                "tmux-mcp-experimental-scroll": set(),
+            }),
+        )
+        assert tmux_lib.resolve_socket("green") == "tmux-mcp"
+
+    def test_finds_session_on_experimental_socket(self, monkeypatch):
+        monkeypatch.setenv("TMUX_MCP_SOCKET", "tmux-mcp")
+        monkeypatch.setattr(
+            tmux_lib.subprocess, "run",
+            self._make_run({
+                "tmux-mcp": {"blue"},
+                "tmux-mcp-experimental-scroll": {"orange"},
+            }),
+        )
+        assert tmux_lib.resolve_socket("orange") == "tmux-mcp-experimental-scroll"
+
+    def test_raises_when_session_missing(self, monkeypatch):
+        monkeypatch.setenv("TMUX_MCP_SOCKET", "tmux-mcp")
+        monkeypatch.setattr(
+            tmux_lib.subprocess, "run",
+            self._make_run({
+                "tmux-mcp": {"blue"},
+                "tmux-mcp-experimental-scroll": {"orange"},
+            }),
+        )
+        with pytest.raises(tmux_lib.SessionNotFoundError):
+            tmux_lib.resolve_socket("nope")
+
+    def test_skips_sockets_with_no_server(self, monkeypatch):
+        monkeypatch.setenv("TMUX_MCP_SOCKET", "tmux-mcp")
+        monkeypatch.setattr(
+            tmux_lib.subprocess, "run",
+            self._make_run({
+                "tmux-mcp": None,
+                "tmux-mcp-experimental-scroll": {"green"},
+            }),
+        )
+        assert tmux_lib.resolve_socket("green") == "tmux-mcp-experimental-scroll"
+
+    def test_recomputes_every_call(self, monkeypatch):
+        monkeypatch.setenv("TMUX_MCP_SOCKET", "tmux-mcp")
+        calls: list[list[str]] = []
+
+        def _run(cmd, capture_output=True, text=True, check=False):
+            calls.append(cmd)
+            return MagicMock(returncode=0, stdout="green\n", stderr="")
+
+        monkeypatch.setattr(tmux_lib.subprocess, "run", _run)
+
+        tmux_lib.resolve_socket("green")
+        first_call_count = len(calls)
+        tmux_lib.resolve_socket("green")
+        assert len(calls) == first_call_count * 2
+
+
+class TestPerSessionSocketPlumbing:
+    """Each public op resolves the socket via resolve_socket and uses it.
+
+    These tests pin `resolve_socket` to a known value and assert the
+    socket actually used by subprocess.run matches.
+    """
+
+    @pytest.fixture
+    def captured(self, monkeypatch):
+        calls: list[list[str]] = []
+
+        def _run(cmd, capture_output=True, text=True, check=False):
+            calls.append(cmd)
+            return MagicMock(
+                returncode=0,
+                stdout="",
+                stderr="",
+            )
+
+        monkeypatch.setattr(tmux_lib.subprocess, "run", _run)
+        return calls
+
+    @staticmethod
+    def _sockets_used(calls: list[list[str]]) -> set[str]:
+        out = set()
+        for cmd in calls:
+            if len(cmd) >= 3 and cmd[0] == "tmux" and cmd[1] == "-L":
+                out.add(cmd[2])
+        return out
+
+    def test_send_interrupt_uses_resolved_socket(self, monkeypatch, captured):
+        monkeypatch.setattr(
+            tmux_lib, "resolve_socket", lambda name: "tmux-mcp-experimental-scroll"
+        )
+        tmux_lib.send_interrupt("orange")
+        assert self._sockets_used(captured) == {"tmux-mcp-experimental-scroll"}
+
+    def test_get_n_last_lines_uses_resolved_socket(self, monkeypatch, captured):
+        monkeypatch.setattr(
+            tmux_lib, "resolve_socket", lambda name: "tmux-mcp-experimental-scroll"
+        )
+        tmux_lib.get_n_last_lines("orange", lines=3)
+        assert self._sockets_used(captured) == {"tmux-mcp-experimental-scroll"}
+
+    def test_send_to_terminal_uses_resolved_socket(self, monkeypatch, captured):
+        monkeypatch.setattr(
+            tmux_lib, "resolve_socket", lambda name: "tmux-mcp-experimental-scroll"
+        )
+        monkeypatch.setattr(
+            tmux_lib, "_generate_random_buffer_name", lambda prefix="": "buf"
+        )
+        tmux_lib.send_to_terminal("orange", "ls")
+        # No verify string -> never reads pane; just buffer ops
+        assert self._sockets_used(captured) == {"tmux-mcp-experimental-scroll"}
+
+    def test_execute_in_terminal_uses_resolved_socket(self, monkeypatch, captured):
+        monkeypatch.setattr(
+            tmux_lib, "resolve_socket", lambda name: "tmux-mcp-experimental-scroll"
+        )
+        tmux_lib.execute_in_terminal("orange", "ls", sync=False)
+        assert self._sockets_used(captured) == {"tmux-mcp-experimental-scroll"}
+
+    def test_propagates_session_not_found(self, monkeypatch, captured):
+        def _raise(name):
+            raise tmux_lib.SessionNotFoundError(name)
+
+        monkeypatch.setattr(tmux_lib, "resolve_socket", _raise)
+        with pytest.raises(tmux_lib.SessionNotFoundError):
+            tmux_lib.send_interrupt("ghost")
+
+
 def test_create_tmux_session_registers_permissions(monkeypatch, tmp_path):
     # Use temp permissions file
     monkeypatch.setenv("TMUX_MCP_PERMISSIONS_FILE", str(tmp_path / "permissions.json"))
@@ -47,21 +234,96 @@ def test_create_tmux_session_sets_minimal_status_right_and_keybinding(monkeypatc
     # We don't assert exact full command order; just that required config was applied.
     joined = [" ".join(c) for c in calls]
 
-    assert any(j.startswith("tmux set-option -t green @tmux_mcp_managed 1") for j in joined), joined
-    assert any(j.startswith("tmux set-option -t green status on") for j in joined), joined
-    assert any(j.startswith("tmux set-option -t green status-interval 5") for j in joined), joined
+    # Plain session => default socket.
+    socket_prefix = "tmux -L tmux-mcp"
+    assert any(j.startswith(f"{socket_prefix} set-option -t green @tmux_mcp_managed 1") for j in joined), joined
+    assert any(j.startswith(f"{socket_prefix} set-option -t green status on") for j in joined), joined
+    assert any(j.startswith(f"{socket_prefix} set-option -t green status-interval 5") for j in joined), joined
     assert any(
-        "tmux set-option -t green status-right" in j and "tmux_mcp_status.py" in j
+        f"{socket_prefix} set-option -t green status-right" in j and "tmux_mcp_status.py" in j
         for j in joined
     ), joined
 
     # Binding is global (no -t <session>), but gated on @tmux_mcp_managed.
     assert any(
-        j.startswith("tmux bind-key -n C-] run-shell")
+        j.startswith(f"{socket_prefix} bind-key -n C-] run-shell")
         and "@tmux_mcp_managed" in j
         and "tmux_mcp_toggle.py" in j
         for j in joined
     ), joined
+
+class TestCreateTmuxSessionSocketChoice:
+    """Tests for socket selection inside create_tmux_session."""
+
+    @pytest.fixture
+    def stub_subprocess(self, monkeypatch):
+        """Capture all tmux calls; list-sessions returns empty by default
+        (no cross-socket dup)."""
+        calls: list[list[str]] = []
+
+        def _run(cmd, capture_output=True, text=True, check=False):
+            calls.append(cmd)
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(tmux_lib.subprocess, "run", _run)
+        monkeypatch.setattr(permissions, "ensure_session_registered", lambda *_: None)
+        return calls
+
+    @staticmethod
+    def _non_listsessions_sockets(calls):
+        return {
+            cmd[2] for cmd in calls
+            if len(cmd) >= 4
+            and cmd[0] == "tmux" and cmd[1] == "-L"
+            and cmd[3] != "list-sessions"
+        }
+
+    def test_default_session_uses_default_socket(self, monkeypatch, stub_subprocess):
+        monkeypatch.setenv("TMUX_MCP_SOCKET", "tmux-mcp")
+        assert tmux_lib.create_tmux_session("green", scroll_popup=False) is True
+        assert self._non_listsessions_sockets(stub_subprocess) == {"tmux-mcp"}
+
+    def test_scroll_popup_session_uses_experimental_socket(
+        self, monkeypatch, stub_subprocess
+    ):
+        monkeypatch.setenv("TMUX_MCP_SOCKET", "tmux-mcp")
+        assert tmux_lib.create_tmux_session("orange", scroll_popup=True) is True
+        assert self._non_listsessions_sockets(stub_subprocess) == {
+            "tmux-mcp-experimental-scroll"
+        }
+
+    def test_returns_socket_used(self, monkeypatch, stub_subprocess):
+        monkeypatch.setenv("TMUX_MCP_SOCKET", "tmux-mcp")
+
+        assert tmux_lib.create_tmux_session(
+            "orange", scroll_popup=True, return_socket=True
+        ) == "tmux-mcp-experimental-scroll"
+        assert tmux_lib.create_tmux_session(
+            "green", scroll_popup=False, return_socket=True
+        ) == "tmux-mcp"
+
+    def test_refuses_when_name_taken_on_other_socket(self, monkeypatch):
+        """'green' lives on the default socket; requesting --scroll-popup
+        on it must hard-fail."""
+        monkeypatch.setenv("TMUX_MCP_SOCKET", "tmux-mcp")
+        monkeypatch.setattr(permissions, "ensure_session_registered", lambda *_: None)
+
+        def _run(cmd, capture_output=True, text=True, check=False):
+            # Only the dup-check probe against the non-target socket returns
+            # a name; everything else is empty.
+            if cmd[3:4] == ["list-sessions"] and cmd[2] == "tmux-mcp":
+                return MagicMock(returncode=0, stdout="green\n", stderr="")
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(tmux_lib.subprocess, "run", _run)
+
+        with pytest.raises(tmux_lib.SessionNameConflictError) as exc:
+            tmux_lib.create_tmux_session("green", scroll_popup=True)
+
+        assert exc.value.session_name == "green"
+        assert exc.value.existing_socket == "tmux-mcp"
+        assert exc.value.target_socket == "tmux-mcp-experimental-scroll"
+
 
 class TestRandomBufferName:
     """Tests for _generate_random_buffer_name function."""
@@ -295,6 +557,11 @@ class TestSendToTerminal:
         monkeypatch.setattr(tmux_lib.subprocess, "run", self.mock_run)
         monkeypatch.setattr(tmux_lib, "_verify_terminal_prompt", self.mock_verify)
         monkeypatch.setattr(tmux_lib, "_generate_random_buffer_name", self.mock_gen_name)
+        # send_to_terminal resolves the socket via resolve_socket();
+        # pin it so the call doesn't depend on real tmux state.
+        monkeypatch.setattr(
+            tmux_lib, "resolve_socket", lambda name: "tmux-mcp"
+        )
 
     def test_send_to_terminal_calls_tmux(self):
         """Verify that send_to_terminal calls the correct tmux commands in order."""
@@ -306,19 +573,20 @@ class TestSendToTerminal:
 
         assert result is True
 
+        sock = "tmux-mcp"
         expected_calls = [
             call(
-                ["tmux", "set-buffer", "-b", buffer_name, cmd],
+                ["tmux", "-L", sock, "set-buffer", "-b", buffer_name, cmd],
                 capture_output=True,
                 text=True,
             ),
             call(
-                ["tmux", "paste-buffer", "-p", "-b", buffer_name, "-t", session],
+                ["tmux", "-L", sock, "paste-buffer", "-p", "-b", buffer_name, "-t", session],
                 capture_output=True,
                 text=True,
             ),
             call(
-                ["tmux", "delete-buffer", "-b", buffer_name],
+                ["tmux", "-L", sock, "delete-buffer", "-b", buffer_name],
                 capture_output=True,
                 text=True,
             ),


### PR DESCRIPTION
scrolling using a tmux popup loading history into less - this allows scrolling without interrupting the agent from actively running commands.

It can be enabled with the `--experimental-scroll-popup` argument when creating a new session with `tmux-cli new`.

When enabled, the popup is opened on scroll up events. The regular scrolling mode (copy-mode) can still be accessed in this mode by using `CTRL+B` then `[` - exiting copy mode with `q`.

Added a config loader which reads from `~/.config/tmux-mcp/config.json` be default and allows setting default arguments when creating new sessions.

